### PR TITLE
Prepare for authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.5"
+
+services:
+  auth:
+    image: quay.io/pusher/oauth2_proxy:v4.1.0
+    container_name: auth_container
+    environment:
+      - OAUTH2_PROXY_CLIENT_ID=6edc861e-267b-455a-ad8f-4a641ad046b8
+      - OAUTH2_PROXY_CLIENT_SECRET=${OAUTH2_PROXY_CLIENT_SECRET}
+      - OAUTH2_PROXY_COOKIE_SECRET=${OAUTH2_PROXY_COOKIE_SECRET}
+      - OAUTH2_PROXY_COOKIE_SECURE=false # only for development
+      - OAUTH2_PROXY_EMAIL_DOMAINS=*
+      - OAUTH2_PROXY_HTTP_ADDRESS=http://:5000
+      - OAUTH2_PROXY_OIDC_ISSUER_URL=https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0
+      - OAUTH2_PROXY_PASS_ACCESS_TOKEN=true
+      - OAUTH2_PROXY_PASS_BASIC_AUTH=false
+      - OAUTH2_PROXY_PASS_USER_HEADERS=false
+      - OAUTH2_PROXY_PROVIDER=oidc
+      - OAUTH2_PROXY_REDIRECT_URL=http://localhost:5000/oauth2/callback
+      - OAUTH2_PROXY_REDIS_CONNECTION_URL=redis://auth-state:6379
+      - OAUTH2_PROXY_SCOPE=openid profile offline_access
+      - OAUTH2_PROXY_SESSION_STORE_TYPE=redis
+      - OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true
+      - OAUTH2_PROXY_UPSTREAMS=http://server:8000
+    networks:
+      - radix
+    ports:
+      - "5000:5000"
+
+  auth-state:
+    image: redis:5-alpine
+    container_name: radix-auth-state_container
+    networks:
+      - radix
+
+  server:
+    build: .
+    ports:
+      - "8000:8000"
+
+networks:
+  radix:
+    name: radix

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -8,12 +8,49 @@ spec:
       build:
         from: master
   components:
+    - name: auth
+      image: quay.io/pusher/oauth2_proxy:v4.1.0 # see https://pusher.github.io/oauth2_proxy/configuration
+      ports:
+        - name: http
+          port: 5000
+      publicPort: http
+      secrets:
+        - OAUTH2_PROXY_CLIENT_SECRET # Azure client secret for AD app
+        - OAUTH2_PROXY_COOKIE_SECRET # Output of `python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'`
+      variables:
+        OAUTH2_PROXY_COOKIE_REFRESH: "60m"
+        OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+        OAUTH2_PROXY_HTTP_ADDRESS: "http://:5000"
+        OAUTH2_PROXY_OIDC_ISSUER_URL: "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0"
+        OAUTH2_PROXY_PASS_ACCESS_TOKEN: "true"
+        OAUTH2_PROXY_PASS_BASIC_AUTH: "false"
+        OAUTH2_PROXY_PASS_USER_HEADERS: "false"
+        OAUTH2_PROXY_PROVIDER: "oidc"
+        OAUTH2_PROXY_REDIS_CONNECTION_URL: "redis://auth-state:6379" # Where to store session info (the auth-state component)
+        OAUTH2_PROXY_SESSION_STORE_TYPE: "redis"
+        OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+        OAUTH2_PROXY_UPSTREAMS: "http://server:8000"
+      environmentConfig:
+        - environment: production
+          variables:
+            OAUTH2_PROXY_CLIENT_ID: "6edc861e-267b-455a-ad8f-4a641ad046b8"
+            OAUTH2_PROXY_REDIRECT_URL: "https://auth-gathering-metis-production.playground.radix.equinor.com/oauth2/callback"
+            OAUTH2_PROXY_SCOPE: "openid profile offline_access"
+
+    # For storing state
+    - name: auth-state
+      image: redis:5-alpine
+      ports:
+        - name: redis
+          port: 6379    
+    
     - name: server
       src: "."
       ports:
        - name: http
          port: 8000
       publicPort: http
+
   dnsAppAlias:
     environment: prod
     component: server


### PR DESCRIPTION
Resolves #6 

Note that the app registration requires admin consent, so we might have to re-use an old test app registration before that is in place.